### PR TITLE
Add Tidal provider

### DIFF
--- a/manual/index.md
+++ b/manual/index.md
@@ -18,19 +18,19 @@ If you would like to contribute with a provider see the [how to](manual/how_to.h
 
 ## Support
 
-| Support   | default     | YouTube           | YouTube Music | SoundCloud    | Netflix          | Spotify       |
-|-----------|-------------|-------------------|---------------|---------------|------------------|---------------|
-| Cover Art | domain logo | video's thumbnail | song's cover  | song's cover  | netflix logo     | song's cover  |
-| Title     | page title  | video's title     | song's title  | song's title  | movie/show title | song's title  |
-| Artists   | page host   | video's owner     | song's artist | song's artist | movie/show       | song's artist |
-| PlayPause | yes         | yes               | yes           | yes           | yes              | yes           |
-| Stop      | yes         | yes               | yes           | yes           | yes              | yes           |
-| Next      | no          | yes               | yes           | yes           | yes              | yes           |
-| Previous  | no          | yes               | yes           | yes           | yes              | yes           |
-| Rate      | no          | yes               | no            | no            | no               | no            |
-| Volume    | yes(no UI)  | yes               | yes           | yes           | yes              | yes           |
-| Shuffle   | no          | yes (if present)  | yes           | yes           | no               | yes           |
-| Loop      | TRACK/NONE  | full              | full          | full          | no               | full          |
+| Support   | default     | YouTube           | YouTube Music | SoundCloud    | Netflix          | Spotify       | Tidal         |
+|-----------|-------------|-------------------|---------------|---------------|------------------|---------------|---------------|
+| Cover Art | domain logo | video's thumbnail | song's cover  | song's cover  | netflix logo     | song's cover  | song's cover  |
+| Title     | page title  | video's title     | song's title  | song's title  | movie/show title | song's title  | song's title  |
+| Artists   | page host   | video's owner     | song's artist | song's artist | movie/show       | song's artist | song's artist |
+| PlayPause | yes         | yes               | yes           | yes           | yes              | yes           | yes           |
+| Stop      | yes         | yes               | yes           | yes           | yes              | yes           | yes           |
+| Next      | no          | yes               | yes           | yes           | yes              | yes           | yes           |
+| Previous  | no          | yes               | yes           | yes           | yes              | yes           | yes           |
+| Rate      | no          | yes               | no            | no            | no               | no            | no            |
+| Volume    | yes(no UI)  | yes               | yes           | yes           | yes              | yes           | yes           |
+| Shuffle   | no          | yes (if present)  | yes           | yes           | no               | yes           | yes           |
+| Loop      | TRACK/NONE  | full              | full          | full          | no               | full          | full          |
 
 ### Loop
 Full loop supports cycling between Playlist Loop, Track Loop, and None

--- a/src/browser/manifest.json
+++ b/src/browser/manifest.json
@@ -110,7 +110,8 @@
       ],
       "exclude_matches": [
         "*://www.google.com/recaptcha/*",
-        "*://google.com/recaptcha/*"
+        "*://google.com/recaptcha/*",
+        "*://mail.goole.com/*"
       ],
       "js": [
         "init.js"

--- a/src/browser/manifest.json
+++ b/src/browser/manifest.json
@@ -96,6 +96,16 @@
     },
     {
       "matches": [
+        "*://listen.tidal.com/*"
+      ],
+      "js": [
+        "providers/tidal.js"
+      ],
+      "run_at": "document_start",
+      "all_frames": true
+    },
+    {
+      "matches": [
         "*://*/*"
       ],
       "exclude_matches": [

--- a/src/browser/providers/tidal.js
+++ b/src/browser/providers/tidal.js
@@ -135,7 +135,7 @@ class TidalPlayback extends Playback {
         super.setVolume(volume);
         if (this.controls.volumeProgress) {
             this.controls.volumeProgress.value = volume * 100;
-            this.control.volumeProgress.style =
+            this.controls.volumeProgress.style =
                 '--val:' + volume * 100 + '; --max:100; --min:0;';
         }
     }
@@ -167,8 +167,9 @@ window.addEventListener('mpris2-setup', function() {
         let loaded = false;
         mutations.forEach(mutation => {
             mutation.addedNodes.forEach(n => {
-                if (n.className.startsWith('footerPlayer')) {
+                if (n.className && n.className.startsWith('footerPlayer')) {
                     loaded = true;
+                    playerObserver.disconnect()
                 }
             });
         });

--- a/src/browser/providers/tidal.js
+++ b/src/browser/providers/tidal.js
@@ -31,17 +31,21 @@ class TidalPlayer extends Player {
     }
 
     getLength() {
-      const elm = this.page.elements.duration;
-      return elm
-        ? (elm.textContent.split(':')[0] * 60 + elm.textContent.split(':')[1]) * 1e6
-        : super.getLength()
+      const duration = this.page.elements.duration;
+      if (duration) {
+        const [min, sec] = duration.textContent.split(':')
+        return (parseInt(min) * 60 + parseInt(sec)) * 1e6
+      }
+      return super.getLength()
     }
 
     getPosition() {
       const currentTime = this.page.elements.currentTime;
-      return currentTime
-        ? (currentTime.textContent.split(':')[0] * 60 + currentTime.textContent.split(':')[1]) * 1e6
-        : super.getLength();
+      if (currentTime) {
+        const [min, sec] = currentTime.textContent.split(':')
+        return (parseInt(min) * 60 + parseInt(sec)) * 1e6
+      }
+      return super.getLength();
     }
 
     getUrl() {

--- a/src/browser/providers/tidal.js
+++ b/src/browser/providers/tidal.js
@@ -1,0 +1,203 @@
+/**
+ *
+ * This file adds support for the Tidal web player
+ *
+ * by extending and overriding the classes {@link Page},
+ * {@link Playback}, and {@link Player}.
+ * we can define how we'll interact with tidal's site
+ *
+ */
+
+class TidalPlayer extends Player {
+
+    getTitle() {
+        const elm = this.page.elements.title;
+        return elm ? elm.textContent : super.getTitle();
+    }
+
+    getArtists() {
+        const elm = this.page.elements.artist;
+        return elm ? [elm.textContent] : super.getArtists();
+    }
+
+    getCover() {
+        const elm = this.page.elements.cover;
+        return elm ? elm.src : super.getCover();
+    }
+
+    isPlaying() {
+        const elm = this.page.playback.controls.play;
+        return elm ? elm.title === 'Pause' : super.isPlaying();
+    }
+
+    getLength() {
+      const elm = this.page.elements.duration;
+      return elm
+        ? (elm.textContent.split(':')[0] * 60 + elm.textContent.split(':')[1]) * 1e3
+        : super.getLength()
+    }
+
+    getPosition() {
+      const currentTime = this.page.elements.currentTime;
+      return currentTime
+        ? (currentTime.textContent.split(':')[0] * 60 + currentTime.textContent.split(':')[1]) * 1e3
+        : super.getLength();
+    }
+
+}
+
+Player = TidalPlayer;
+
+class TidalPlayback extends Playback {
+
+    canGoNext() {
+        return !!this.controls.next;
+    }
+
+    next() {
+        const elm = this.controls.next;
+        (elm && elm.click()) || super.next();
+    }
+
+    canGoPrevious() {
+        return !!this.controls.prev;
+    }
+
+    previous() {
+        (this.controls.prev && this.controls.prev.click()) || super.previous();
+    }
+
+    setShuffle(isShuffle) {
+        if (this.controls.shuffle) {
+            if ((!this.isShuffle() && isShuffle) || (this.isShuffle() && !isShuffle)){
+                this.controls.shuffle.click();
+            }
+        }
+    }
+
+    isShuffle() {
+      if (this.controls.shuffle) {
+          const classes = Array.from(this.controls.shuffle.classList);
+          return classes.some(c => c.startsWith("active"));
+      } else {
+        return super.isShuffle();
+      }
+    }
+
+    getLoopStatus() {
+        if (this.controls.repeat) {
+            const classes = Array.from(this.controls.repeat.classList);
+            if (classes.some(c => c.startsWith("once"))) {
+                return LoopStatus.TRACK;
+            } else if (classes.some(c => c.startsWith("all"))) {
+                return LoopStatus.PLAYLIST;
+            } else {
+                return LoopStatus.NONE;
+            }
+        } else {
+            return super.getLoopStatus();
+        }
+    }
+
+    setLoopStatus(status) {
+        if (this.controls.repeat)
+            this.controls.repeat.click();
+        else
+            super.setLoopStatus(status);
+    }
+
+    setVolume(volume) {
+        super.setVolume(volume);
+        if (this.controls.volumeProgress) {
+            this.controls.volumeProgress.value = volume * 100;
+          this.control.volumeProgress.style = "--val:" + volume * 100 + "; --max:100; --min:0;"
+        }
+    }
+
+    getVolume() {
+        if (this.controls.volumeProgress) {
+            return parseInt(this.controls.volumeProgress.value, 10) / 100
+        }
+        return super.getVolume()
+    }
+
+    setRate() {
+        // disabled
+    }
+
+}
+
+Playback = TidalPlayback;
+
+
+window.addEventListener('mpris2-setup', function () {
+
+  /*
+   * Since tidal is loaded dynamically, we need to wait until the playback controls are added
+   * to the DOM before we can get the elements.
+   *
+   * We create an observer to monitor the added nodes, and set the playback controls when the
+   * player is loaded.
+   *
+   */
+  const playerObserver = new MutationObserver((mutations) => {
+    let loaded = false
+    mutations.forEach(mutation => {
+      mutation.addedNodes.forEach(n => {
+        if (n.className.startsWith('footerPlayer')){
+          loaded = true
+        }
+      })
+    })
+
+    if (loaded) {
+        const BUTTONS_CONTAINER = 'div[class*="playbackControls"]';
+
+        page.playback.controls = {
+          shuffle: document.querySelector(BUTTONS_CONTAINER + ' button:nth-child(1)'),
+          prev: document.querySelector(BUTTONS_CONTAINER + ' button:nth-child(2)'),
+          play: document.querySelector(BUTTONS_CONTAINER + ' button:nth-child(3)'),
+          next: document.querySelector(BUTTONS_CONTAINER + ' button:nth-child(4)'),
+          repeat: document.querySelector(BUTTONS_CONTAINER + ' button:nth-child(5)'),
+          volumeProgress: document.querySelector('div[class*="volumeSlider"] input')
+        };
+
+
+        page.elements = {
+          title: document.querySelector('span[class*="mediaItemTitle"]'),
+          artist: document.querySelector('div[class*="mediaArtists"]'),
+          cover: document.querySelector('figure[class*="mediaImagery"] img'),
+          duration: document.querySelector('time[class*="duration"]'),
+          currentTime: document.querySelector('time[class*="currentTime"]')
+
+        }
+
+
+        const observer = new MutationObserver(() => {
+          page.host.change();
+        });
+
+        Object.values(page.playback.controls).forEach(control => {
+          observer.observe(control, {
+            attributes: true,
+            childList: true,
+            subtree: true
+          });
+        });
+
+
+        page.playback.controls.shuffle
+          .addEventListener('click', () => page.host.change());
+        page.playback.controls.repeat
+          .addEventListener('click', () => page.host.change());
+    }
+  })
+
+
+  playerObserver.observe(document, {
+    childList: true,
+    subtree: true
+  })
+
+
+});

--- a/src/browser/providers/tidal.js
+++ b/src/browser/providers/tidal.js
@@ -164,17 +164,17 @@ window.addEventListener('mpris2-setup', function() {
      *
      */
     const playerObserver = new MutationObserver(mutations => {
-        let loaded = false;
         mutations.forEach(mutation => {
             mutation.addedNodes.forEach(n => {
                 if (n.className && n.className.startsWith('footerPlayer')) {
-                    loaded = true;
+                    initPage()
                     playerObserver.disconnect()
                 }
             });
         });
+    })
 
-        if (loaded) {
+      const initPage = () => {
             const BUTTONS_CONTAINER = 'div[class*="playbackControls"]';
 
             page.playback.controls = {
@@ -258,7 +258,6 @@ window.addEventListener('mpris2-setup', function() {
                 page.host.change()
             );
         }
-    });
 
     playerObserver.observe(document, {
         childList: true,

--- a/src/browser/providers/tidal.js
+++ b/src/browser/providers/tidal.js
@@ -9,7 +9,6 @@
  */
 
 class TidalPlayer extends Player {
-
     getTitle() {
         const elm = this.page.elements.title;
         return elm ? elm.textContent : super.getTitle();
@@ -31,34 +30,32 @@ class TidalPlayer extends Player {
     }
 
     getLength() {
-      const duration = this.page.elements.duration;
-      if (duration) {
-        const [min, sec] = duration.textContent.split(':')
-        return (parseInt(min) * 60 + parseInt(sec)) * 1e6
-      }
-      return super.getLength()
+        const duration = this.page.elements.duration;
+        if (duration) {
+            const [min, sec] = duration.textContent.split(':');
+            return (parseInt(min) * 60 + parseInt(sec)) * 1e6;
+        }
+        return super.getLength();
     }
 
     getPosition() {
-      const currentTime = this.page.elements.currentTime;
-      if (currentTime) {
-        const [min, sec] = currentTime.textContent.split(':')
-        return (parseInt(min) * 60 + parseInt(sec)) * 1e6
-      }
-      return super.getLength();
+        const currentTime = this.page.elements.currentTime;
+        if (currentTime) {
+            const [min, sec] = currentTime.textContent.split(':');
+            return (parseInt(min) * 60 + parseInt(sec)) * 1e6;
+        }
+        return super.getLength();
     }
 
     getUrl() {
-      const link = this.page.elements.url;
-      return link ? link.href : super.getUrl()
+        const link = this.page.elements.url;
+        return link ? link.href : super.getUrl();
     }
-
 }
 
 Player = TidalPlayer;
 
 class TidalPlayback extends Playback {
-
     canGoNext() {
         return !!this.controls.next;
     }
@@ -77,42 +74,49 @@ class TidalPlayback extends Playback {
     }
 
     play() {
-        !this.activePlayer.isPlaying()
-        && (this.controls.play && this.controls.play.click()) || super.play();
+        (!this.activePlayer.isPlaying() &&
+            this.controls.play &&
+            this.controls.play.click()) ||
+            super.play();
     }
 
     pause() {
-        this.activePlayer.isPlaying()
-        && (this.controls.play && this.controls.play.click()) || super.pause()
+        (this.activePlayer.isPlaying() &&
+            this.controls.play &&
+            this.controls.play.click()) ||
+            super.pause();
     }
 
     playPause() {
-      (this.controls.play && this.controls.play.click()) || super.playPause()
+        (this.controls.play && this.controls.play.click()) || super.playPause();
     }
 
     setShuffle(isShuffle) {
         if (this.controls.shuffle) {
-            if ((!this.isShuffle() && isShuffle) || (this.isShuffle() && !isShuffle)){
+            if (
+                (!this.isShuffle() && isShuffle) ||
+                (this.isShuffle() && !isShuffle)
+            ) {
                 this.controls.shuffle.click();
             }
         }
     }
 
     isShuffle() {
-      if (this.controls.shuffle) {
-          const classes = Array.from(this.controls.shuffle.classList);
-          return classes.some(c => c.startsWith("active"));
-      } else {
-        return super.isShuffle();
-      }
+        if (this.controls.shuffle) {
+            const classes = Array.from(this.controls.shuffle.classList);
+            return classes.some(c => c.startsWith('active'));
+        } else {
+            return super.isShuffle();
+        }
     }
 
     getLoopStatus() {
         if (this.controls.repeat) {
             const classes = Array.from(this.controls.repeat.classList);
-            if (classes.some(c => c.startsWith("once"))) {
+            if (classes.some(c => c.startsWith('once'))) {
                 return LoopStatus.TRACK;
-            } else if (classes.some(c => c.startsWith("all"))) {
+            } else if (classes.some(c => c.startsWith('all'))) {
                 return LoopStatus.PLAYLIST;
             } else {
                 return LoopStatus.NONE;
@@ -123,123 +127,140 @@ class TidalPlayback extends Playback {
     }
 
     setLoopStatus(status) {
-        if (this.controls.repeat)
-            this.controls.repeat.click();
-        else
-            super.setLoopStatus(status);
+        if (this.controls.repeat) this.controls.repeat.click();
+        else super.setLoopStatus(status);
     }
 
     setVolume(volume) {
         super.setVolume(volume);
         if (this.controls.volumeProgress) {
             this.controls.volumeProgress.value = volume * 100;
-          this.control.volumeProgress.style = "--val:" + volume * 100 + "; --max:100; --min:0;"
+            this.control.volumeProgress.style =
+                '--val:' + volume * 100 + '; --max:100; --min:0;';
         }
     }
 
     getVolume() {
         if (this.controls.volumeProgress) {
-            return parseInt(this.controls.volumeProgress.value, 10) / 100
+            return parseInt(this.controls.volumeProgress.value, 10) / 100;
         }
-        return super.getVolume()
+        return super.getVolume();
     }
 
     setRate() {
         // disabled
     }
-
 }
 
 Playback = TidalPlayback;
 
-
-window.addEventListener('mpris2-setup', function () {
-
-  /*
-   * Since tidal is loaded dynamically, we need to wait until the playback controls are added
-   * to the DOM before we can get the elements.
-   *
-   * We create an observer to monitor the added nodes, and set the playback controls when the
-   * player is loaded.
-   *
-   */
-  const playerObserver = new MutationObserver((mutations) => {
-    let loaded = false
-    mutations.forEach(mutation => {
-      mutation.addedNodes.forEach(n => {
-        if (n.className.startsWith('footerPlayer')){
-          loaded = true
-        }
-      })
-    })
-
-    if (loaded) {
-        const BUTTONS_CONTAINER = 'div[class*="playbackControls"]';
-
-        page.playback.controls = {
-          shuffle: document.querySelector(BUTTONS_CONTAINER + ' button:nth-child(1)'),
-          prev: document.querySelector(BUTTONS_CONTAINER + ' button:nth-child(2)'),
-          play: document.querySelector(BUTTONS_CONTAINER + ' button:nth-child(3)'),
-          next: document.querySelector(BUTTONS_CONTAINER + ' button:nth-child(4)'),
-          volumeProgress: document.querySelector('div[class*="volumeSlider"] input')
-        };
-
-        // We also reset the repeat button, since this might change
-        const setRepeatElement = () => {
-          page.playback.controls.repeat = document.querySelector(
-            BUTTONS_CONTAINER + ' button:nth-child(5)');
-          // We might not be playing from a playlist, in this case the repeat button is
-          // replaced with a block button, which we dont want do click.
-          if (page.playback.controls.repeat.className.startsWith("blockButton")){
-              page.playback.controls.repeat == null;
-          }
-
-        }
-
-
-        const setPageElements = () => {
-          page.elements = {
-            title: document.querySelector('span[class*="mediaItemTitle"]'),
-            artist: document.querySelector('div[class*="mediaArtists"]'),
-            cover: document.querySelector('figure[class*="mediaImagery"] img'),
-            duration: document.querySelector('time[class*="duration"]'),
-            currentTime: document.querySelector('time[class*="currentTime"]'),
-            url: document.querySelector('div[class*="playingFrom"] a')
-          }
-        }
-
-        setPageElements();
-        setRepeatElement();
-
-        const observer = new MutationObserver(() => {
-          setPageElements();
-          setRepeatElement();
-          page.host.change();
-        });
-
-        // We observe all relevant elements to see if we need to update.
-        [...Object.values(page.playback.controls), ...Object.values(page.elements)].forEach(
-          control => {
-            observer.observe(control, {
-              attributes: true,
-              childList: true,
-              subtree: true
+window.addEventListener('mpris2-setup', function() {
+    /*
+     * Since tidal is loaded dynamically, we need to wait until the playback controls are added
+     * to the DOM before we can get the elements.
+     *
+     * We create an observer to monitor the added nodes, and set the playback controls when the
+     * player is loaded.
+     *
+     */
+    const playerObserver = new MutationObserver(mutations => {
+        let loaded = false;
+        mutations.forEach(mutation => {
+            mutation.addedNodes.forEach(n => {
+                if (n.className.startsWith('footerPlayer')) {
+                    loaded = true;
+                }
             });
         });
 
+        if (loaded) {
+            const BUTTONS_CONTAINER = 'div[class*="playbackControls"]';
 
-        page.playback.controls.shuffle
-          .addEventListener('click', () => page.host.change());
-        page.playback.controls.repeat
-          .addEventListener('click', () => page.host.change());
-    }
-  })
+            page.playback.controls = {
+                shuffle: document.querySelector(
+                    BUTTONS_CONTAINER + ' button:nth-child(1)'
+                ),
+                prev: document.querySelector(
+                    BUTTONS_CONTAINER + ' button:nth-child(2)'
+                ),
+                play: document.querySelector(
+                    BUTTONS_CONTAINER + ' button:nth-child(3)'
+                ),
+                next: document.querySelector(
+                    BUTTONS_CONTAINER + ' button:nth-child(4)'
+                ),
+                volumeProgress: document.querySelector(
+                    'div[class*="volumeSlider"] input'
+                )
+            };
 
+            // We also reset the repeat button, since this might change
+            const setRepeatElement = () => {
+                page.playback.controls.repeat = document.querySelector(
+                    BUTTONS_CONTAINER + ' button:nth-child(5)'
+                );
+                // We might not be playing from a playlist, in this case the repeat button is
+                // replaced with a block button, which we dont want do click.
+                if (
+                    page.playback.controls.repeat.className.startsWith(
+                        'blockButton'
+                    )
+                ) {
+                    page.playback.controls.repeat == null;
+                }
+            };
 
-  playerObserver.observe(document, {
-    childList: true,
-    subtree: true
-  })
+            const setPageElements = () => {
+                page.elements = {
+                    title: document.querySelector(
+                        'span[class*="mediaItemTitle"]'
+                    ),
+                    artist: document.querySelector(
+                        'div[class*="mediaArtists"]'
+                    ),
+                    cover: document.querySelector(
+                        'figure[class*="mediaImagery"] img'
+                    ),
+                    duration: document.querySelector('time[class*="duration"]'),
+                    currentTime: document.querySelector(
+                        'time[class*="currentTime"]'
+                    ),
+                    url: document.querySelector('div[class*="playingFrom"] a')
+                };
+            };
 
+            setPageElements();
+            setRepeatElement();
 
+            const observer = new MutationObserver(() => {
+                setPageElements();
+                setRepeatElement();
+                page.host.change();
+            });
+
+            // We observe all relevant elements to see if we need to update.
+            [
+                ...Object.values(page.playback.controls),
+                ...Object.values(page.elements)
+            ].forEach(control => {
+                observer.observe(control, {
+                    attributes: true,
+                    childList: true,
+                    subtree: true
+                });
+            });
+
+            page.playback.controls.shuffle.addEventListener('click', () =>
+                page.host.change()
+            );
+            page.playback.controls.repeat.addEventListener('click', () =>
+                page.host.change()
+            );
+        }
+    });
+
+    playerObserver.observe(document, {
+        childList: true,
+        subtree: true
+    });
 });


### PR DESCRIPTION
Adds a provider for the Tidal web player.
Everything works as it should, with some minor caveats. Play/Pause seems to be a bit buggy, but this seems to be an issue in general.

Seeking, setting track position, loop, shuffle etc. all works.

The only thing is that the player is not recognized before you play a video, which I believe is due to the fact that there is no audio element in the dom. However, just queuing a video seems to do the trick, after that it's fine.

I also added gmail to the block list, because hangouts was being picked up, so I had a useless media player for all my gmail tabs. (I can remove this if necessary) 
